### PR TITLE
Debug blank github pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/lolognz.github.io/',
+  base: '/',
 })


### PR DESCRIPTION
Fix blank GitHub Pages site by correcting Vite's base path for `username.github.io` repositories.

For `username.github.io` repositories, GitHub Pages serves content from the root (`/`). The previous `base: '/lolognz.github.io/'` caused Vite to look for assets in an incorrect subpath, resulting in a blank page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9162d22-c91c-4428-af30-f9d223ab5df0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9162d22-c91c-4428-af30-f9d223ab5df0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

